### PR TITLE
Improve Sentimo sync commands

### DIFF
--- a/Block/System/Config/Form/Date.php
+++ b/Block/System/Config/Form/Date.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sentimo\ReviewAnalysis\Block\Systrem\Config\Form;
+namespace Sentimo\ReviewAnalysis\Block\System\Config\Form;
 
 use Magento\Config\Block\System\Config\Form\Field;
 use Magento\Framework\Data\Form\Element\AbstractElement;

--- a/Model/Command/PostReviewsCommand.php
+++ b/Model/Command/PostReviewsCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sentimo\ReviewAnalysis\Model\Command;
 
-use Sentimo\Client\HttpClient\ClientFactory;
 use Sentimo\ReviewAnalysis\Api\ReviewProviderInterface;
 use Sentimo\ReviewAnalysis\Model\Adapter\ReviewAdapter;
 use Sentimo\ReviewAnalysis\Model\Client;
@@ -33,13 +32,21 @@ class PostReviewsCommand
             return;
         }
 
-        $reviewsToPost = [];
+        $reviews = $this->reviewProvider->getNotSyncedReviews();
 
-        foreach ($this->reviewProvider->getNotSyncedReviews() as $review) {
-            $reviewsToPost[] = $this->adapter->adaptTo($review);
+        if ($reviews === []) {
+            return;
         }
 
+        $reviewsToPost = array_map([$this->adapter, 'adaptTo'], $reviews);
+
         $reviewIds = $this->client->postReviews($reviewsToPost);
-        $this->reviewAnalysisSyncResource->updateReviewsStatus($reviewIds, ReviewAnalysisSync::STATUS_IN_PROGRESS);
+
+        if ($reviewIds !== []) {
+            $this->reviewAnalysisSyncResource->updateReviewsStatus(
+                $reviewIds,
+                ReviewAnalysisSync::STATUS_IN_PROGRESS
+            );
+        }
     }
 }

--- a/Model/Command/SyncReviewsCommand.php
+++ b/Model/Command/SyncReviewsCommand.php
@@ -41,6 +41,11 @@ class SyncReviewsCommand
         }
 
         $reviewIds = $this->reviewProvider->getSyncInProgressReviewIds();
+
+        if ($reviewIds === []) {
+            return;
+        }
+
         $batches = $this->splitIntoBatches($reviewIds, self::BATCH_SIZE);
 
         $sentimoReviews = [];
@@ -51,9 +56,7 @@ class SyncReviewsCommand
                 true
             );
 
-            foreach ($batchReviews as $review) {
-                $sentimoReviews[] = $review; // Append reviews directly
-            }
+            $sentimoReviews = array_merge($sentimoReviews, $batchReviews);
         }
 
         if (empty($sentimoReviews)) {
@@ -98,14 +101,17 @@ class SyncReviewsCommand
      */
     private function getReviewIds(array $sentimoReviews): array
     {
-        $reviewIds = [];
-
-        foreach ($sentimoReviews as $sentimoReview) {
-            if ($sentimoReview->getExternalId() !== null) {
-                $reviewIds[] = (int) $sentimoReview->getExternalId();
-            }
-        }
-
-        return $reviewIds;
+        return array_values(
+            array_filter(
+                array_map(
+                    static function ($sentimoReview) {
+                        return $sentimoReview->getExternalId() !== null
+                            ? (int) $sentimoReview->getExternalId()
+                            : null;
+                    },
+                    $sentimoReviews
+                )
+            )
+        );
     }
 }

--- a/Model/ReviewProvider.php
+++ b/Model/ReviewProvider.php
@@ -20,7 +20,7 @@ class ReviewProvider implements ReviewProviderInterface
      * @param \Sentimo\ReviewAnalysis\Model\Config $config
      */
     public function __construct(
-        private readonly Collectionfactory $reviewCollectionFactory,
+        private readonly CollectionFactory $reviewCollectionFactory,
         private readonly ReviewAnalysisSyncCollectionFactory $reviewAnalysisCollectionFactory,
         private readonly Config $config
     ) {

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -39,12 +39,12 @@
                 <label>Date Range for Review Sync</label>
                 <field id="from_date" translate="label" type="date" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>From Date</label>
-                    <frontend_model>Sentimo\ReviewAnalysis\Block\Systrem\Config\Form\Date</frontend_model>
+                    <frontend_model>Sentimo\ReviewAnalysis\Block\System\Config\Form\Date</frontend_model>
                     <comment>Date from which reviews will be considered for sync.</comment>
                 </field>
                 <field id="to_date" translate="label" type="date" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>To Date</label>
-                    <frontend_model>Sentimo\ReviewAnalysis\Block\Systrem\Config\Form\Date</frontend_model>
+                    <frontend_model>Sentimo\ReviewAnalysis\Block\System\Config\Form\Date</frontend_model>
                     <comment>Date until which reviews will be considered for sync.</comment>
                 </field>
             </group>


### PR DESCRIPTION
## Summary
- streamline PostReviewsCommand for sharper review export
- improve flow in SyncReviewsCommand with early exits
- fix type hint for review collection factory
- correct `System` date field namespace

## Testing
- `composer install`
- `vendor/bin/phpunit Test/Unit/Model/ClientTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68812d450ee0832aa9b3ce10a1f56b6f